### PR TITLE
Add missing yarn install in github deploy action example

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
       - name: Build and deploy to AWS
         run: node_modules/.bin/cdk-nuxt-deploy-server
         env:


### PR DESCRIPTION
Hey @ferdinandfrank, while integrating GitHub automated actions deploy, I noticed that the README.md file in the example you provided is missing the `yarn install` command. I've added it to the file.